### PR TITLE
Changed Error Messages to display API Response

### DIFF
--- a/lib/screens/login/login2.dart
+++ b/lib/screens/login/login2.dart
@@ -143,7 +143,6 @@ class _LoginFirebaseScreenState extends State<LoginFirebaseScreen> {
 
   void handleSignIn(context) async {
     FirebaseUser user;
-    String errorMessage;
     final form = formKey.currentState;
     _toggleLoadingStatus(true);
     if (form.validate()) {
@@ -153,42 +152,21 @@ class _LoginFirebaseScreenState extends State<LoginFirebaseScreen> {
             email: _email, password: _password);
         user = result.user;
       } catch (error) {
-        switch (error.code) {
-          case "ERROR_INVALID_EMAIL":
-            errorMessage = "Your email address appears to be malformed.";
-            break;
-          case "ERROR_WRONG_PASSWORD":
-            errorMessage = "Your password is wrong.";
-            break;
-          case "ERROR_USER_NOT_FOUND":
-            errorMessage = "User with this email doesn't exist.";
-            break;
-          case "ERROR_USER_DISABLED":
-            errorMessage = "User with this email has been disabled.";
-            break;
-          case "ERROR_TOO_MANY_REQUESTS":
-            errorMessage = "Too many requests. Try again later.";
-            break;
-          case "ERROR_OPERATION_NOT_ALLOWED":
-            errorMessage = "Signing in with Email and Password is not enabled.";
-            break;
-          default:
-            errorMessage = error.code == null
-                ? "An undefined Error happened."
-                : error.code;
+        if (error.message != null) {
+          _showSnackBar(error.message);
+        } else {
+          _showSnackBar('An unexpected error occured!');
         }
+        _toggleLoadingStatus(false);
+        return null;
       }
     }
     _toggleLoadingStatus(false);
-    if (errorMessage != null) {
-      _showSnackBar(errorMessage);
+    if (!user.isEmailVerified) {
+      _showSnackBar("Email not verified");
+      await _auth.signOut();
     } else {
-      if (!user.isEmailVerified) {
-        _showSnackBar("Email not verified");
-        await _auth.signOut();
-      } else {
-        Navigator.pop(context);
-      }
+      Navigator.pop(context);
     }
   }
 

--- a/lib/screens/register/register.dart
+++ b/lib/screens/register/register.dart
@@ -173,7 +173,6 @@ class _RegisterFirebaseScreenState extends State<RegisterFirebaseScreen> {
 
   void handleRegister(context) async {
     FirebaseUser user;
-    String errorMessage;
     final form = formKey.currentState;
     if (form.validate()) {
       form.save();
@@ -193,27 +192,14 @@ class _RegisterFirebaseScreenState extends State<RegisterFirebaseScreen> {
             email: _email, password: _password);
         user = result.user;
       } catch (error) {
-        switch (error.code) {
-          case "ERROR_WEAK_PASSWORD":
-            errorMessage = "Your password appears to be weak.";
-            break;
-          case "ERROR_INVALID_EMAIL":
-            errorMessage = "Your email address appears to be malformed.";
-            break;
-          case "ERROR_EMAIL_ALREADY_IN_USE":
-            errorMessage = "User with this email already exist.";
-            break;
-          default:
-            errorMessage = error.code == null
-                ? "An undefined Error happened."
-                : error.code;
+        if (error.message != null) {
+          _showSnackBar(error.message);
+        } else {
+          _showSnackBar('An unexpected error occured!');
         }
+        _toggleLoadingStatus(false);
+        return null;
       }
-    }
-    if (errorMessage != null) {
-      _toggleLoadingStatus(false);
-      _showSnackBar(errorMessage);
-      return null;
     }
     await _store
         .collection('username')
@@ -224,21 +210,11 @@ class _RegisterFirebaseScreenState extends State<RegisterFirebaseScreen> {
       updateInfo.displayName = _name;
       await user.updateProfile(updateInfo);
     } catch (error) {
-      switch (error.code) {
-        case "ERROR_USER_DISABLED":
-          errorMessage = "Your acount has been disabled";
-          break;
-        case "ERROR_USER_NOT_FOUND":
-          errorMessage = "Account not found";
-          break;
-        default:
-          errorMessage =
-              error.code == null ? "An undefined Error happened." : error.code;
+      if (error.message != null) {
+        _showSnackBar(error.message);
+      } else {
+        _showSnackBar('An unexpected error occured!');
       }
-    }
-    if (errorMessage != null) {
-      _toggleLoadingStatus(false);
-      _showSnackBar(errorMessage);
       return null;
     }
     await user.sendEmailVerification();
@@ -247,9 +223,10 @@ class _RegisterFirebaseScreenState extends State<RegisterFirebaseScreen> {
     Navigator.pushReplacement(
       context,
       MaterialPageRoute(
-          builder: (BuildContext context) => LoginFirebaseScreen(
-              snackBarMessage:
-                  'A verification link has been sent to your e-mail account')),
+        builder: (BuildContext context) => LoginFirebaseScreen(
+            snackBarMessage:
+                'A verification link has been sent to your e-mail account'),
+      ),
     );
   }
 }

--- a/lib/utils/network.dart
+++ b/lib/utils/network.dart
@@ -37,13 +37,21 @@ class NetworkUtil {
         .post(url,
             body: json.encode(body), headers: headers, encoding: encoding)
         .then((http.Response response) {
-      final String res = response.body;
+      final res = response.body;
       final int statusCode = response.statusCode;
       if (statusCode == 401) {
         throw new Exception(statusCode.toString() + "Invalid Credentials");
+      } else if (statusCode == 400) {
+        final resData = json.decode(res);
+        var validationErrorData = resData['validationErrors'];
+        List<Map<String, dynamic>> errors = [];
+        validationErrorData.entries.forEach(((err) => errors.add(err.value)));
+        if (errors.isNotEmpty) {
+          throw Exception(
+              statusCode.toString() + " " + errors[0].values.toString());
+        }
       } else if (statusCode < 200 || statusCode > 400 || json == null) {
-        throw new Exception(
-            statusCode.toString() + "Error while fetching data");
+        throw Exception(statusCode.toString() + "Error while fetching data");
       }
       return _decoder.convert(res);
     });


### PR DESCRIPTION
**Description**

API response sends an error message on failure. Now we're showing that to the User instead of hardcoded messages.

**Testing Methods**

1. Firebase - By Logging in or Registering with invalid inputs
2. By manually creating a validation error. E.g. Add a patient with an invalid birthdate

**Screenshots/Videos**

<div style="flex-direction: row; margin-bottom: 10px;">
<img src='https://user-images.githubusercontent.com/45410599/94988389-7450a500-058a-11eb-9b84-23a62c2f8280.png' height='500px' style="margin-right: 10px;" />
<img src='https://user-images.githubusercontent.com/45410599/104088042-f63b2300-5289-11eb-98c0-d9f791b5dd8d.jpg' height='500px' />
</div>

**New Packages Added**

N/A

**Closing Issues**

closes #25 
